### PR TITLE
Atualiza documentação do parâmetro mailLookupClass.

### DIFF
--- a/documentation/reference/pt-BR/configuracao.xml
+++ b/documentation/reference/pt-BR/configuracao.xml
@@ -151,7 +151,7 @@
 				adicione a opção
 				<emphasis>frameworkdemoiselle.mail.type=provided</emphasis>
 				. Depois, você deve colocar também a opção
-				<emphasis>frameworkdemoiselle.mail.lookup_class</emphasis>
+				<emphasis>frameworkdemoiselle.mail.mailLookupClass</emphasis>
 				. O valor vai depender de qual servidor você está usando.
 			</para>
 			<para>


### PR DESCRIPTION
A documentação faz referência ao parâmetro de configuração
`frameworkdemoiselle.mail.lookup_class` mas, ao menos no Demoiselle 2.4, a
classe `br.gov.frameworkdemoiselle.mail.internal.Config` espera um parâmetro
com o nome `frameworkdemoiselle.mail.mailLookupClass`.
